### PR TITLE
 Compute fileIdentifier in UnidataDD2MI.xsl as specified by ACDD

### DIFF
--- a/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
+++ b/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
@@ -178,7 +178,7 @@
             </xsl:attribute>
             <gmd:fileIdentifier>
                 <xsl:call-template name="writeCharacterString">
-                    <xsl:with-param name="stringToWrite" select="concat($identifierNameSpace[1], '.', $id[1])"/>
+                    <xsl:with-param name="stringToWrite" select="concat($identifierNameSpace[1], ':', $id[1])"/>
                 </xsl:call-template>
             </gmd:fileIdentifier>
             <gmd:language>

--- a/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
+++ b/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
@@ -28,7 +28,7 @@
     <xsl:variable name="standardNameCnt" select="count(/nc:netcdf/nc:variable/nc:attribute[@name='standard_name'])"/>
     <xsl:variable name="dimensionCnt" select="count(/nc:netcdf/nc:dimension)"/>
     <!-- Identifier Fields: 4 possible -->
-    <xsl:variable name="id" as="xs:string*" select="(/nc:netcdf/nc:group[@name='THREDDSMetadata']/nc:attribute[@name='id']/@value,/nc:netcdf/nc:attribute[@name='id']/@value)"/>
+    <xsl:variable name="id" as="xs:string*" select="(/nc:attribute[@name='id']/@value,/nc:netcdf/nc:attribute[@name='id']/@value,/nc:netcdf/nc:group[@name='THREDDSMetadata']/nc:attribute[@name='id']/@value)"/>
     <xsl:variable name="identifierNameSpace" as="xs:string*" select="(/nc:netcdf/nc:attribute[@name='naming_authority']/@value,
     /nc:netcdf/nc:group[@name='THREDDSMetadata']/nc:attribute[@name='authority']/@value)"/>
     <xsl:variable name="metadataConvention" as="xs:string*" select="/nc:netcdf/nc:attribute[@name='Metadata_Conventions']/@value"/>
@@ -178,7 +178,7 @@
             </xsl:attribute>
             <gmd:fileIdentifier>
                 <xsl:call-template name="writeCharacterString">
-                    <xsl:with-param name="stringToWrite" select="$id[1]"/>
+                    <xsl:with-param name="stringToWrite" select="concat($identifierNameSpace[1], '.', $id[1])"/>
                 </xsl:call-template>
             </gmd:fileIdentifier>
             <gmd:language>

--- a/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
+++ b/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
@@ -175,15 +175,10 @@
         <gmi:MI_Metadata>
             <xsl:attribute name="xsi:schemaLocation">
                 <xsl:value-of select="'http://www.isotc211.org/2005/gmi http://www.ngdc.noaa.gov/metadata/published/xsd/schema.xsd'"/>
-            </xsl:attribute>            
+            </xsl:attribute>
             <gmd:fileIdentifier>
                 <xsl:call-template name="writeCharacterString">
-                    <xsl:with-param name="stringToWrite">
-                        <xsl:choose>
-                            <xsl:when test="$identifierNameSpace"><xsl:value-of select="concat($identifierNameSpace[1],':',$id[1])"/></xsl:when>
-                            <xsl:otherwise><xsl:value-of select="$id[1]"/></xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:with-param>
+                    <xsl:with-param name="stringToWrite" select="concat($identifierNameSpace[1], '.', $id[1])"/>
                 </xsl:call-template>
             </gmd:fileIdentifier>
             <gmd:language>
@@ -1084,7 +1079,7 @@
     <xsl:template name="writeCharacterString">
         <xsl:param name="stringToWrite"/>
         <xsl:choose>
-            <xsl:when test="normalize-space($stringToWrite)">
+            <xsl:when test="$stringToWrite">
                 <gco:CharacterString>
                     <xsl:value-of select="$stringToWrite"/>
                 </gco:CharacterString>

--- a/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
+++ b/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.1" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nc="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" exclude-result-prefixes="nc">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nc="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" exclude-result-prefixes="nc">
     <xd:doc xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" scope="stylesheet">
         <xd:desc>
         Recent Modifications
@@ -175,10 +175,15 @@
         <gmi:MI_Metadata>
             <xsl:attribute name="xsi:schemaLocation">
                 <xsl:value-of select="'http://www.isotc211.org/2005/gmi http://www.ngdc.noaa.gov/metadata/published/xsd/schema.xsd'"/>
-            </xsl:attribute>
+            </xsl:attribute>            
             <gmd:fileIdentifier>
                 <xsl:call-template name="writeCharacterString">
-                    <xsl:with-param name="stringToWrite" select="concat($identifierNameSpace[1], ':', $id[1])"/>
+                    <xsl:with-param name="stringToWrite">
+                        <xsl:choose>
+                            <xsl:when test="$identifierNameSpace"><xsl:value-of select="concat($identifierNameSpace[1],':',$id[1])"/></xsl:when>
+                            <xsl:otherwise><xsl:value-of select="$id[1]"/></xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:with-param>
                 </xsl:call-template>
             </gmd:fileIdentifier>
             <gmd:language>
@@ -1079,7 +1084,7 @@
     <xsl:template name="writeCharacterString">
         <xsl:param name="stringToWrite"/>
         <xsl:choose>
-            <xsl:when test="$stringToWrite">
+            <xsl:when test="normalize-space($stringToWrite)">
                 <gco:CharacterString>
                     <xsl:value-of select="$stringToWrite"/>
                 </gco:CharacterString>


### PR DESCRIPTION
This PR fixes  #10.

We implemented this change on our development 4.6 TDS server, and it worked:
The `naming_authority` and `id` specified in the [OPeNDAP Dataset Access Form](http://geoport-dev.whoi.edu/thredds/dodsC/usgs/data0/bbleh/spring2012/00_dir_roms.ncml.html)
```
id: COAWST.Barnegat_Bay.spring2012
naming_authority: gov.usgs.marine
```
are reflected in the `fileIdentifier` in the [ISO metadata](http://geoport-dev.whoi.edu/thredds/iso/usgs/data0/bbleh/spring2012/00_dir_roms.ncml?catalog=http%3A%2F%2Fgeoport-dev.whoi.edu%2Fthredds%2Fcatalog%2Fusgs%2Fdata0%2Fbbleh%2Fspring2012%2Fcatalog.html&dataset=usgs%2Fdata0%2Fbbleh%2Fspring2012%2F00_dir_roms.ncml):
```
   <gmd:fileIdentifier>
     <gco:CharacterString>gov.usgs.marine.COAWST.Barnegat_Bay.spring2012</gco:CharacterString>
   </gmd:fileIdentifier>
```