### PR TITLE
Use standard_names when calculating extent, add tests

### DIFF
--- a/src/test/java/thredds/server/metadata/util/ThreddsExtentUtilTest.java
+++ b/src/test/java/thredds/server/metadata/util/ThreddsExtentUtilTest.java
@@ -1,0 +1,63 @@
+package thredds.server.metadata.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import thredds.server.metadata.bean.Extent;
+
+public class ThreddsExtentUtilTest {
+    private Extent getExtent(String file) throws Exception {
+        return ThreddsExtentUtil.getExtent("file:src/test/resources/extent/" + file + ".ncml");
+    }
+    
+    @Test
+    public void testExtent() throws Exception {
+        Extent extent = getExtent("test");
+        validateExtent(extent);
+
+        assertEquals("up", extent._vOrientation);
+        assertEquals(-10.0, extent._minHeight, 1E-20);
+        assertEquals(0.0, extent._maxHeight, 1E-20);
+    }
+
+    @Test
+    public void testExtentPositiveDown() throws Exception {
+        Extent extent = getExtent("test_positive_down");
+        validateExtent(extent);
+
+        assertEquals("down", extent._vOrientation);
+        assertEquals(0.0, extent._minHeight, 1E-20);
+        assertEquals(10.0, extent._maxHeight, 1E-20);
+    }
+
+    @Test
+    public void testExtentStandardNames() throws Exception {
+        Extent extent = getExtent("test_standard_names");
+        validateExtent(extent);
+
+        assertEquals("up", extent._vOrientation);
+        assertEquals(-10.0, extent._minHeight, 1E-20);
+        assertEquals(0.0, extent._maxHeight, 1E-20);
+    }
+
+    private void validateExtent(Extent extent) throws Exception {
+        assertEquals(39.0, extent._minLat, 1E-20);
+        assertEquals(41.0, extent._maxLat, 1E-20);
+        assertEquals("degrees_north", extent._latUnits);
+        assertEquals(1.0, extent._latRes, 1E-20);
+        
+        assertEquals(-109.0, extent._minLon, 1E-20);
+        assertEquals(-105.0, extent._maxLon, 1E-20);
+        assertEquals("degrees_east", extent._lonUnits);
+        assertEquals(2.0, extent._lonRes, 1E-20);
+
+        assertEquals("2015-01-01T06:00:00Z", extent._minTime);
+        assertEquals("2015-01-01T18:00:00Z", extent._maxTime);
+        assertEquals("seconds", extent._timeUnits);
+        assertEquals("P0Y0M0DT12H0M0.000S", extent._timeDuration);
+        assertEquals("43200.0", extent._timeRes);
+
+        assertEquals(10.0, extent._heightRes, 1E-20);
+        assertEquals("meters", extent._heightUnits);
+    }
+}

--- a/src/test/java/thredds/server/metadata/util/ThreddsExtentUtilTest.java
+++ b/src/test/java/thredds/server/metadata/util/ThreddsExtentUtilTest.java
@@ -1,43 +1,36 @@
 package thredds.server.metadata.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import thredds.server.metadata.bean.Extent;
 
 public class ThreddsExtentUtilTest {
     private Extent getExtent(String file) throws Exception {
         return ThreddsExtentUtil.getExtent("file:src/test/resources/extent/" + file + ".ncml");
     }
-    
+
     @Test
     public void testExtent() throws Exception {
-        Extent extent = getExtent("test");
-        validateExtent(extent);
-
-        assertEquals("up", extent._vOrientation);
-        assertEquals(-10.0, extent._minHeight, 1E-20);
-        assertEquals(0.0, extent._maxHeight, 1E-20);
+        validateExtent(getExtent("test"));
     }
 
     @Test
     public void testExtentPositiveDown() throws Exception {
-        Extent extent = getExtent("test_positive_down");
-        validateExtent(extent);
-
-        assertEquals("down", extent._vOrientation);
-        assertEquals(0.0, extent._minHeight, 1E-20);
-        assertEquals(10.0, extent._maxHeight, 1E-20);
+        validateExtent(getExtent("test_positive_down"));
     }
 
     @Test
     public void testExtentStandardNames() throws Exception {
-        Extent extent = getExtent("test_standard_names");
-        validateExtent(extent);
+        validateExtent(getExtent("test_standard_names"));
+    }
 
-        assertEquals("up", extent._vOrientation);
-        assertEquals(-10.0, extent._minHeight, 1E-20);
-        assertEquals(0.0, extent._maxHeight, 1E-20);
+    @Test
+    public void testExtentMultipleTimeStdNames() throws Exception {
+        validateExtent(getExtent("test_multiple_time_std_names"));
     }
 
     private void validateExtent(Extent extent) throws Exception {
@@ -59,5 +52,15 @@ public class ThreddsExtentUtilTest {
 
         assertEquals(10.0, extent._heightRes, 1E-20);
         assertEquals("meters", extent._heightUnits);
+        assertNotNull(extent._vOrientation);
+        if (extent._vOrientation.equalsIgnoreCase("up")) {
+            assertEquals(-10.0, extent._minHeight, 1E-20);
+            assertEquals(0.0, extent._maxHeight, 1E-20);
+        } else if (extent._vOrientation.equalsIgnoreCase("down")) {
+            assertEquals(0.0, extent._minHeight, 1E-20);
+            assertEquals(10.0, extent._maxHeight, 1E-20);
+        } else {
+            fail("Invalid vOrientation value: " + extent._vOrientation);
+        }
     }
 }

--- a/src/test/resources/extent/test.ncml
+++ b/src/test/resources/extent/test.ncml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <dimension name="time" length="2" isUnlimited="true" />
+  <dimension name="lat" length="3" />
+  <dimension name="lon" length="3" />
+  <dimension name="depth" length="2" />
+
+  <variable name="lat" shape="lat" type="float">
+    <attribute name="units" type="String" value="degrees_north" />
+    <values>41.0 40.0 39.0</values>
+  </variable>
+
+  <variable name="lon" shape="lon" type="float">
+    <attribute name="units" type="String" value="degrees_east" />
+    <values>-109.0 -107.0 -105.0</values>
+  </variable>
+
+  <variable name="time" shape="time" type="int">
+    <attribute name="units" type="String" value="hours since 2015-01-01T00:00:00Z" />
+    <values>6 18</values>
+  </variable>
+
+  <variable name="depth" shape="depth" type="float">
+    <attribute name="units" type="String" value="meters" />
+    <attribute name="positive" type="String" value="up" />
+    <values>0.0 -10.0</values>
+  </variable>
+
+  <variable name="temp" shape="time lat lon depth" type="double">
+    <attribute name="long_name" type="String" value="air temperature" />
+    <attribute name="standard_name" type="String" value="air_temperature" />
+    <attribute name="units" type="String" value="degrees_Celsius" />
+  </variable>
+</netcdf>

--- a/src/test/resources/extent/test_multiple_time_std_names.ncml
+++ b/src/test/resources/extent/test_multiple_time_std_names.ncml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <dimension name="time" length="2" isUnlimited="true" />
+  <dimension name="forecast_time" length="2" isUnlimited="true" />
+  <dimension name="lat" length="3" />
+  <dimension name="lon" length="3" />
+  <dimension name="depth" length="2" />
+
+  <variable name="lat" shape="lat" type="float">
+    <attribute name="units" type="String" value="degrees_north" />
+    <values>41.0 40.0 39.0</values>
+  </variable>
+
+  <variable name="lon" shape="lon" type="float">
+    <attribute name="units" type="String" value="degrees_east" />
+    <values>-109.0 -107.0 -105.0</values>
+  </variable>
+
+  <variable name="forecast_time" shape="forecast_time" type="int">
+    <attribute name="standard_name" type="String" value="time" />
+    <attribute name="units" type="String" value="hours since 2015-01-01T00:00:00Z" />    
+    <values>4 16</values>
+  </variable>
+
+  <variable name="time" shape="time" type="int">
+    <attribute name="standard_name" type="String" value="time" />
+    <attribute name="units" type="String" value="hours since 2015-01-01T00:00:00Z" />    
+    <values>6 18</values>
+  </variable>
+
+  <variable name="depth" shape="depth" type="float">
+    <attribute name="units" type="String" value="meters" />
+    <attribute name="positive" type="String" value="down" />
+    <values>0.0 10.0</values>
+  </variable>
+
+  <variable name="temp" shape="time lat lon depth" type="double">
+    <attribute name="long_name" type="String" value="air temperature" />
+    <attribute name="standard_name" type="String" value="air_temperature" />
+    <attribute name="units" type="String" value="degrees_Celsius" />
+  </variable>
+</netcdf>

--- a/src/test/resources/extent/test_positive_down.ncml
+++ b/src/test/resources/extent/test_positive_down.ncml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <dimension name="time" length="2" isUnlimited="true" />
+  <dimension name="lat" length="3" />
+  <dimension name="lon" length="3" />
+  <dimension name="depth" length="2" />
+
+  <variable name="lat" shape="lat" type="float">
+    <attribute name="units" type="String" value="degrees_north" />
+    <values>41.0 40.0 39.0</values>
+  </variable>
+
+  <variable name="lon" shape="lon" type="float">
+    <attribute name="units" type="String" value="degrees_east" />
+    <values>-109.0 -107.0 -105.0</values>
+  </variable>
+
+  <variable name="time" shape="time" type="int">
+    <attribute name="units" type="String" value="hours since 2015-01-01T00:00:00Z" />
+    <values>6 18</values>
+  </variable>
+
+  <variable name="depth" shape="depth" type="float">
+    <attribute name="units" type="String" value="meters" />
+    <attribute name="positive" type="String" value="down" />
+    <values>0.0 10.0</values>
+  </variable>
+
+  <variable name="temp" shape="time lat lon depth" type="double">
+    <attribute name="long_name" type="String" value="air temperature" />
+    <attribute name="standard_name" type="String" value="air_temperature" />
+    <attribute name="units" type="String" value="degrees_Celsius" />
+  </variable>
+</netcdf>

--- a/src/test/resources/extent/test_standard_names.ncml
+++ b/src/test/resources/extent/test_standard_names.ncml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <dimension name="axis3" length="2" isUnlimited="true" />
+  <dimension name="axis1" length="3" />
+  <dimension name="axis2" length="3" />
+  <dimension name="axis4" length="2" />
+
+  <variable name="axis1" shape="axis1" type="float">
+    <attribute name="standard_name" type="String" value="latitude" />
+    <attribute name="units" type="String" value="degrees_north" />
+    <values>41.0 40.0 39.0</values>
+  </variable>
+
+  <variable name="axis2" shape="axis2" type="float">
+    <attribute name="standard_name" type="String" value="longitude" />
+    <attribute name="units" type="String" value="degrees_east" />
+    <values>-109.0 -107.0 -105.0</values>
+  </variable>
+
+  <variable name="axis3" shape="axis3" type="int">
+    <attribute name="standard_name" type="String" value="time" />
+    <attribute name="units" type="String" value="hours since 2015-01-01T00:00:00Z" />
+    <values>6 18</values>
+  </variable>
+
+  <variable name="axis4" shape="axis4" type="float">
+    <attribute name="standard_name" type="String" value="altitude" />
+    <attribute name="units" type="String" value="meters" />
+    <attribute name="positive" type="String" value="up" />
+    <values>0.0 -10.0</values>
+  </variable>
+
+  <variable name="temp" shape="axis3 axis1 axis2 axis4" type="double">
+    <attribute name="long_name" type="String" value="air temperature" />
+    <attribute name="standard_name" type="String" value="air_temperature" />
+    <attribute name="units" type="String" value="degrees_Celsius" />
+  </variable>
+</netcdf>


### PR DESCRIPTION
This commit changes ThreddsExtentUtil to use a set of new methods (variableHasAttribute, variableHasFullName, findTimeAxis, etc) when looking for extent axes. These new methods incorporate using standard_names, add more standard_name and variable name matches for z axes, and ensure that only one matching variable/axis is found for each extent dimension.

When determining the time axis, [ThreddsExtentUtil.findTimeAxis](https://github.com/Unidata/threddsIso/blob/a0bb6b16f7ad64e98b44b3018a80f6e51b8adff7/src/main/java/thredds/server/metadata/util/ThreddsExtentUtil.java#L156) first collects all axes with standard_name="time". If there is a single match, that axis is used. If there are no matches, a variable named "time" is searched for. If there are multiple axes with standard_name="time" those axes are searched for a variable named "time". If a matching variable is found that axis is used, otherwise the first axis with standard_name="time" is used. This should satisfy the requirements described in https://github.com/Unidata/threddsIso/issues/9#issuecomment-94181010.

Unit tests were added for ThreddsExtentUtil and test ncml files were created. Additional test ncml files can be created to test more formats.

A bug in setting lat/lon extent units for feature datasets is also fixed. 

