### PR TITLE
allow flexible gmd:MD_TopicCategoryCode

### DIFF
--- a/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
+++ b/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
@@ -669,7 +669,7 @@
                     <xsl:for-each select="tokenize($ISOTopicCategories[1],$topicDelimiter)">
                       <gmd:topicCategory>
                         <gmd:MD_TopicCategoryCode>
-                          <xsl:value-of select="."/>
+                          <xsl:value-of select="normalize-space(.)"/>
                         </gmd:MD_TopicCategoryCode>
                       </gmd:topicCategory>
                     </xsl:for-each>

--- a/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
+++ b/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
@@ -3,6 +3,7 @@
     <xd:doc xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" scope="stylesheet">
         <xd:desc>
         Recent Modifications
+            <xd:p>2016-01-13. Allow gmd:MD_TopicCategoryCode to have values other than "climateMeteorologyAtmosphere" by pulling NetCDF global attribute "ISO_Topic_Categories" if available.</xd:p>
             <xd:p>2015-07-28. update //srv:SV_ServiceIdentification/srv:serviceType/gco:LocalName to provide appropriate lookup from https://github.com/OSGeo/Cat-Interop/blob/master/LinkPropertyLookupTable.csv to align with OGC CSW ISO Application Profile Table 14 apiso:ServiceType semantics. Tom Kralidis</xd:p>
             <xd:p>2015-04-22. v2.3.4. concat naming_authority and id in fileIdentifier; change XSLT version to 1.0.</xd:p>
             <xd:p>2015-02-18. resolution value = missing when not available in NcML.</xd:p>
@@ -36,6 +37,8 @@
     <xsl:variable name="metadataConvention" as="xs:string*" select="/nc:netcdf/nc:attribute[@name='Metadata_Conventions']/@value"/>
     <xsl:variable name="metadataLink" as="xs:string*" select="(/nc:netcdf/nc:attribute[@name='Metadata_Link']/@value,
     /nc:netcdf/nc:group[@name='THREDDSMetadata']/nc:group[@name='documentation']/nc:group[@name='document']/nc:attribute[@name='xlink']/@value)"/>
+    <xsl:variable name="ISOTopicCategories" as="xs:string*" select="(/nc:netcdf/nc:attribute[@name='ISO_Topic_Categories']/@value,
+    'climatologyMeteorologyAtmosphere')"/>
     <!-- Service Fields: 4 possible -->
     <xsl:variable name="thredds_netcdfsubsetCnt" select="count(/nc:netcdf/nc:group[@name='THREDDSMetadata']/nc:group[@name='services']/nc:attribute[@name='nccs_service'])"/>
     <xsl:variable name="thredds_opendapCnt" select="count(/nc:netcdf/nc:group[@name='THREDDSMetadata']/nc:group[@name='services']/nc:attribute[@name='opendap_service'])"/>
@@ -653,9 +656,23 @@
                     <gmd:language>
                         <gco:CharacterString>eng</gco:CharacterString>
                     </gmd:language>
-                    <gmd:topicCategory>
-                        <gmd:MD_TopicCategoryCode>climatologyMeteorologyAtmosphere</gmd:MD_TopicCategoryCode>
-                    </gmd:topicCategory>
+                    <xsl:variable name="topicDelimiter">
+                      <xsl:choose>
+                        <xsl:when test="(contains($ISOTopicCategories[1],','))">
+                          <xsl:value-of select="','"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <xsl:value-of select="' '"/>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                    </xsl:variable>
+                    <xsl:for-each select="tokenize($ISOTopicCategories[1],$topicDelimiter)">
+                      <gmd:topicCategory>
+                        <gmd:MD_TopicCategoryCode>
+                          <xsl:value-of select="."/>
+                        </gmd:MD_TopicCategoryCode>
+                      </gmd:topicCategory>
+                    </xsl:for-each>
                     <gmd:extent>
                         <xsl:choose>
                             <xsl:when test="$extentTotal">


### PR DESCRIPTION
So far, ncISO only provides a single hard-coded ISO Topic Category (climatologyMeteorologyAtmosphere), which may not always be appropriate. For example, we would rather use "oceans" in many cases or "elevations", etc. And in some cases more than one ISO Topic Category may be desired (e.g. "biota" and "oceans"). In order to provide some flexibility in this field, this ncISO update uses a NetCDF global attribute named "ISO_Topic_Categories" if defined. It so, it parses the entry by either a comma or a space to look for multiple ISO topics. Otherwise, it defaults to climatologyMeteorologyAtmosphere like before.

FYI: For a list and description of possible ISO Topic Categories, see: https://geo-ide.noaa.gov/wiki/index.php?title=ISO_Topic_Categories.