### PR TITLE
strip white space from keywords

### DIFF
--- a/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
+++ b/src/main/resources/xsl/nciso/UnidataDD2MI.xsl
@@ -445,7 +445,7 @@
                                 <xsl:for-each select="tokenize($keywords[1],$keywordDelimiter)">
                                     <gmd:keyword>
                                         <gco:CharacterString>
-                                            <xsl:value-of select="."/>
+                                            <xsl:value-of select="normalize-space(.)"/>
                                         </gco:CharacterString>
                                     </gmd:keyword>
                                 </xsl:for-each>


### PR DESCRIPTION
If the NetCDF global attribute "keywords" is a comma-separated list and there are spaces between entries (e.g. "temperature, salinity"), this small update adds "normalize-space( )" to prevent such space from appearing before the tokenized topic categories in the resulting ISO XML document (e.g. " temperature" will become "temperature").

For example, if your NetCDF global attributes look like this:

``` xml
          <attribute name="keywords" value="Earth Science Services &gt; Models &gt; Ocean General Circulation Models (OGCM)/Regional Ocean Models, Earth Science Services &gt; Models &gt; Weather Research/Forecast Models, Earth Science &gt; Oceans &gt; Ocean Temperature &gt; Potential Temperature, Earth Science &gt; Oceans &gt; Salinity/Density &gt; Salinity, Earth Science &gt; Oceans &gt; Sea Surface Topography &gt; Sea Surface Height, Earth Science &gt; Oceans &gt; Ocean Circulation &gt; Ocean Currents"/>
          <attribute name="keywords_vocabulary" value="GCMD Science Keywords"/>
```

This update avoids having this kind of ISO XML output:

``` xml
         <theme>
            <themekt>GCMD Science Keywords</themekt>
            <themekey>Earth Science Services &gt; Models &gt; Ocean General Circulation Models (OGCM)/Regional Ocean Models</themekey>
            <themekey> Earth Science Services &gt; Models &gt; Weather Research/Forecast Models</themekey>
            <themekey> Earth Science &gt; Oceans &gt; Ocean Temperature &gt; Potential Temperature</themekey>
            <themekey> Earth Science &gt; Oceans &gt; Salinity/Density &gt; Salinity</themekey>
            <themekey> Earth Science &gt; Oceans &gt; Sea Surface Topography &gt; Sea Surface Height</themekey>
            <themekey> Earth Science &gt; Oceans &gt; Ocean Circulation &gt; Ocean Currents</themekey>
         </theme>
```

and will instead result in this output (with leading spaces before "Earth Science" stripped out):

``` xml
         <theme>
            <themekt>GCMD Science Keywords</themekt>
            <themekey>Earth Science Services &gt; Models &gt; Ocean General Circulation Models (OGCM)/Regional Ocean Models</themekey>
            <themekey>Earth Science Services &gt; Models &gt; Weather Research/Forecast Models</themekey>
            <themekey>Earth Science &gt; Oceans &gt; Ocean Temperature &gt; Potential Temperature</themekey>
            <themekey>Earth Science &gt; Oceans &gt; Salinity/Density &gt; Salinity</themekey>
            <themekey>Earth Science &gt; Oceans &gt; Sea Surface Topography &gt; Sea Surface Height</themekey>
            <themekey>Earth Science &gt; Oceans &gt; Ocean Circulation &gt; Ocean Currents</themekey>
         </theme>
```
