### PR TITLE
Fix nciso version in metadata

### DIFF
--- a/nciso-common/src/main/java/thredds/server/metadata/nciso/util/NCMLModifier.java
+++ b/nciso-common/src/main/java/thredds/server/metadata/nciso/util/NCMLModifier.java
@@ -30,6 +30,7 @@ package thredds.server.metadata.nciso.util;
 
 import com.google.common.html.HtmlEscapers;
 import com.google.common.xml.XmlEscapers;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -37,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 
 import com.google.common.escape.Escaper;
+import java.util.Properties;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
 
@@ -63,7 +65,7 @@ import ucar.nc2.units.TimeDuration;
 public class NCMLModifier {
   static private org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(NCMLModifier.class);
 	private String _openDapService = null;
-	private String _version = "2.2.3";
+	private String _version = "2.4";
 	private static DecimalFormat dFmt = new DecimalFormat(".#####");
   private Escaper xmlEscaper = XmlEscapers.xmlAttributeEscaper();
 	private Escaper htmlEscaper = HtmlEscapers.htmlEscaper();
@@ -417,7 +419,18 @@ public class NCMLModifier {
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 		String metadata_creation_date = sdf.format(dateStamp);
 		addElem(groupElem, "metadata_creation", metadata_creation_date);
-		addElem(groupElem, "nciso_version", _version);
+		addElem(groupElem, "nciso_version", getVersion());
+	}
+
+	private String getVersion() {
+		try {
+			final Properties properties = new Properties();
+			properties.load(getClass().getClassLoader().getResourceAsStream("project.properties"));
+			final String version = properties.getProperty("version");
+			return version == null ? _version : version;
+		} catch (IOException e) {
+			return _version;
+		}
 	}
 
 	private Element newGroupElement() {

--- a/nciso-common/src/main/java/thredds/server/metadata/nciso/util/NCMLModifier.java
+++ b/nciso-common/src/main/java/thredds/server/metadata/nciso/util/NCMLModifier.java
@@ -422,7 +422,8 @@ public class NCMLModifier {
 		addElem(groupElem, "nciso_version", getVersion());
 	}
 
-	private String getVersion() {
+	// package private for testing
+	String getVersion() {
 		try {
 			final Properties properties = new Properties();
 			properties.load(getClass().getClassLoader().getResourceAsStream("project.properties"));

--- a/nciso-common/src/main/resources/project.properties
+++ b/nciso-common/src/main/resources/project.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/nciso-common/src/test/java/thredds/server/metadata/nciso/util/NCMLModiferTest.java
+++ b/nciso-common/src/test/java/thredds/server/metadata/nciso/util/NCMLModiferTest.java
@@ -1,9 +1,8 @@
-package thredds.server.metadata.util;
+package thredds.server.metadata.nciso.util;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
-import thredds.server.metadata.nciso.util.NCMLModifier;
 
 
 public class NCMLModiferTest {
@@ -16,5 +15,4 @@ public class NCMLModiferTest {
 
         assertThat("-.0").isEqualTo(fmtDbl);
     }
-
 }

--- a/nciso-common/src/test/java/thredds/server/metadata/nciso/util/NCMLModiferTest.java
+++ b/nciso-common/src/test/java/thredds/server/metadata/nciso/util/NCMLModiferTest.java
@@ -15,4 +15,11 @@ public class NCMLModiferTest {
 
         assertThat("-.0").isEqualTo(fmtDbl);
     }
+
+    @Test
+    public void testVersion() {
+        final NCMLModifier ncmlModifier = new NCMLModifier();
+        final String version = ncmlModifier.getVersion();
+        assertThat(version.matches("\\d+\\.\\d+\\.\\d+-SNAPSHOT|\\d+\\.\\d+\\.\\d+")).isTrue();
+    }
 }

--- a/nciso-common/src/test/java/thredds/server/metadata/nciso/util/ThreddsExtentUtilTest.java
+++ b/nciso-common/src/test/java/thredds/server/metadata/nciso/util/ThreddsExtentUtilTest.java
@@ -1,4 +1,4 @@
-package thredds.server.metadata.nciso;
+package thredds.server.metadata.nciso.util;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
@@ -6,7 +6,6 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import thredds.server.metadata.nciso.bean.Extent;
-import thredds.server.metadata.nciso.util.ThreddsExtentUtil;
 
 public class ThreddsExtentUtilTest {
     private Extent getExtent(String file) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,15 @@
         <version>${maven-shade-plugin.versoin}</version>
       </plugin>
     </plugins>
+    <resources>
+      <resource>
+        <directory>../nciso-common/src/main/resources/</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>project.properties</include>
+        </includes>
+      </resource>
+    </resources>
   </build>
   <properties>
     <!-- default is to skip tests. use mvn test -DskipTests=false to override on command line -->


### PR DESCRIPTION
The version used in the `NCMLModifier` was hard coded to "2.2.3", which obviously has not been updated with every release. This PR:

- gets version from maven by adding a project.properties, and adding that as a resource in the build phase to the pom. This causes the `${project.version}` to get filled in with the current version with the project is built. That version can then be used by getting that property. 
- Add unit test that the version is being retrieved
- Move unit tests `ThreddsExtentUtilTest` and `NCMLModifierTest` to the correct package for the class they are testing.