### PR TITLE
Deploy to downloads-tds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>edu.ucar</groupId>
         <artifactId>tds-plugin-bom</artifactId>
-        <version>5.5-SNAPSHOT</version>
+        <version>${tds.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -177,6 +177,11 @@
         <artifactId>maven-shade-plugin</artifactId>
         <version>${maven-shade-plugin.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>wagon-maven-plugin</artifactId>
+        <version>${wagon-maven-plugin.version}</version>
+      </plugin>
     </plugins>
     <resources>
       <resource>
@@ -204,5 +209,10 @@
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+    <wagon-maven-plugin.version>2.0.2</wagon-maven-plugin.version>
+
+    <!-- TDS version, and version for the download-tds artifacts repository (without SNAPSHOT) -->
+    <tds.version>5.5-SNAPSHOT</tds.version>
+    <downloads-tds.version>5.5</downloads-tds.version>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@
         <artifactId>wagon-maven-plugin</artifactId>
         <version>${wagon-maven-plugin.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven-antrun-plugin.version}</version>
+      </plugin>
     </plugins>
     <resources>
       <resource>
@@ -210,6 +215,7 @@
     <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
     <wagon-maven-plugin.version>2.0.2</wagon-maven-plugin.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
 
     <!-- TDS version, and version for the download-tds artifacts repository (without SNAPSHOT) -->
     <tds.version>5.5-SNAPSHOT</tds.version>

--- a/tds-plugin/pom.xml
+++ b/tds-plugin/pom.xml
@@ -121,6 +121,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>wagon-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>upload-to-downloads-page</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>upload-single</goal>
+            </goals>
+            <configuration>
+              <fromFile>${build.directory}/${project.build.finalName}-jar-with-dependencies.${project.packaging}</fromFile>
+              <url>https://artifacts.unidata.ucar.edu/content/repositories/downloads-tds/${downloads-tds.version}/</url>
+              <!-- Server ID to use for authentication -->
+              <serverId>unidata-snapshots</serverId>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/tds-plugin/pom.xml
+++ b/tds-plugin/pom.xml
@@ -122,6 +122,27 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>checksum</id>
+            <phase>package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target name="generate_checksum">
+                <property name="file" value="${build.directory}/${project.build.finalName}-jar-with-dependencies.jar"/>
+                <checksum algorithm="md5" file="${file}"/>
+                <checksum algorithm="sha1" file="${file}"/>
+                <checksum algorithm="sha-256" fileext=".sha256" file="${file}"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>wagon-maven-plugin</artifactId>
         <executions>
@@ -129,10 +150,11 @@
             <id>upload-to-downloads-page</id>
             <phase>deploy</phase>
             <goals>
-              <goal>upload-single</goal>
+              <goal>upload</goal>
             </goals>
             <configuration>
-              <fromFile>${build.directory}/${project.build.finalName}-jar-with-dependencies.${project.packaging}</fromFile>
+              <fromDir>${build.directory}</fromDir>
+              <includes>${project.build.finalName}-jar-with-dependencies.*</includes>
               <url>https://artifacts.unidata.ucar.edu/content/repositories/downloads-tds/${downloads-tds.version}/</url>
               <!-- Server ID to use for authentication -->
               <serverId>unidata-snapshots</serverId>


### PR DESCRIPTION
Deploy the tds-plugin-jar-with-dependencies artifact to the downloads-tds repo on nexus. I had to add a new plugin for this, as I was unable to get the maven deploy plugin to work (it wants to deploy to the correct groupId/artifactId so like `EDS/tds-plugin` instead of the `5.5` folder).

Add sha1, sha256, md5 checksum files to the downloads-tds page as well.