### PR TITLE
Update JDK to 17

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
       - name: Build and test with Maven
         run: mvn clean package
 

--- a/.github/workflows/threddsIso-tests.yml
+++ b/.github/workflows/threddsIso-tests.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against latest 11 and 14
+        # test against latest 17 and 21
         distribution: [zulu, adopt]
-        java: [ 11, 14 ]
+        java: [ 17, 21 ]
         profile: [ dev, prod ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Update GitHub actions to JDK to 17+, needed in order to work with latest TDS 5.6-SNAPSHOT which is on JDK 17