### PR TITLE
Upgrade to netCDF-Java 5.9.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The NOAA/NGDC ncISO team and the Unidata THREDDS team work closely (and with the
 
 | netCDF-Java / TDS Version | threddsISO     | threddsISO Tag |
 |:--------------------------|:---------------|:---------------|
-| 5.8.0 / 5.7-SNAPSHOT      | 2.4.8-SNAPSHOT |                |
+| 5.9.0 / 5.7-SNAPSHOT      | 2.4.8-SNAPSHOT |                |
 | 5.7.0 / 5.6               | 2.4.7          | **v2.4.7**     |
 | 5.6.0 / 5.5               | 2.4.6          | **v2.4.6**     |
 | 5.5.3 / 5.4               | 2.4.5          | **v2.4.5**     |

--- a/tds-plugin/pom.xml
+++ b/tds-plugin/pom.xml
@@ -92,7 +92,27 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skip>${skipTests}</skip>
+          <excludedGroups>thredds.server.metadata.Integration</excludedGroups>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.1.2</version>
+        <configuration>
+          <skip>${skipTests}</skip>
+          <includes>
+            <include>**/*</include>
+          </includes>
+          <groups>thredds.server.metadata.Integration</groups>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -103,45 +123,6 @@
             <exclude>**/logback.xml</exclude>
           </excludes>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-        </configuration>
-        <executions>
-          <execution>
-            <id>make-assembly</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>checksum</id>
-            <phase>package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target name="generate_checksum">
-                <property name="file" value="${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar"/>
-                <checksum algorithm="md5" file="${file}"/>
-                <checksum algorithm="sha1" file="${file}"/>
-                <checksum algorithm="sha-256" fileext=".sha256" file="${file}"/>
-              </target>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/tds-plugin/src/test/java/thredds/server/metadata/Integration.java
+++ b/tds-plugin/src/test/java/thredds/server/metadata/Integration.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package thredds.server.metadata;
+
+public interface Integration { }


### PR DESCRIPTION
Also, now that TDS 5.7-SNAPSHOT bundles in code from tds-plugin, we needed to make some some changes to the testcontainer environment to ensure it uses the nciso-common and tds-plugin classes from this repo and not those bundled with the TDS. Additionally, the integration test requiring the testcontainer infrastructure is now run as part of the verify lifecycle and excluded from the test lifecycle.